### PR TITLE
Add command registry

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,31 @@ function metalman (conf) {
   }
 }
 
+metalman.commands = function (opts) {
+  var all = {}
+  var middlewares = []
+  var command = metalman(middlewares)
+
+  var api = {
+    use: function (middleware) {
+      middlewares.push(middleware)
+    },
+    call: function (name, cmd, callback) {
+      all[name](cmd, callback)
+    },
+    expose: function () {
+      return all
+    },
+    define: function (name, config) {
+      config.name = name
+      all[name] = command(config)
+      return api
+    }
+  }
+
+  return api
+}
+
 function commandFactory (config, opts) {
   var commandMiddlewares = opts.middlewares
     .map(createMiddlewares(config, opts))


### PR DESCRIPTION
This just adds some syntactic sugar.
Not sure yet whether this is favorable because it enforces you to go all in with this library.

```js
var registry = require('metalman').commands()

registry.use(middleware)
registry.use(anotherMiddleware)

registry.define('CreateUser', function (cmd, cb) {
  // create user here
})

// .call(cmd, cb) executes a single command
registry.call('CreateUser', cmd, callback)

// .expose() returns an object with all commands
var commands = registry.expose()

// So you can call it directly
commands.CreateUser(cmd, callback)
```